### PR TITLE
New CRE Rule: Redis Rejects Writes Due to Maxmemory Limit

### DIFF
--- a/rules/cre-2025-0071/redis-omm-rejection.yaml
+++ b/rules/cre-2025-0071/redis-omm-rejection.yaml
@@ -1,0 +1,74 @@
+rules:
+  - cre:
+      id: CRE-2025-0071
+      severity: 1
+      title: "Redis Rejects Writes Due to Reaching 'maxmemory' Limit"
+      category: "database-problem"
+      author: "Andre Muta"
+      description: |
+        The Redis instance has reached its configured 'maxmemory' limit. Because its active memory
+        management policy does not permit the eviction of existing keys to free up space (as is the
+        case when the 'noeviction' policy is in effect, which is often the default), Redis rejects
+        new write commands by sending an "OOM command not allowed" error to the client.
+      cause: |
+        - Redis 'maxmemory' limit has been reached.
+        - The active memory management policy prevents key eviction to make space (e.g., 'noeviction' policy is active by default or configuration).
+        - Application attempting to write data exceeding the available 'maxmemory'.
+      impact: |
+        - CRITICAL: Inability to write new data or modify data in a way that increases memory usage.
+        - Potential data loss if critical incoming writes are not handled by client applications.
+        - Service degradation or failure for application components dependent on Redis writes.
+      impactScore: 9
+      tags:
+        - redis
+        - redis-cli
+        - oom
+        - maxmemory
+        - memory-limit
+        - write-failure
+      mitigation: |
+        IMMEDIATE ACTIONS:
+        - **Verify Client Errors:** Check application logs for "(error) OOM command not allowed when used memory > 'maxmemory'" messages.
+        - **Check Redis State (`redis-cli`):**
+          - `INFO memory`: Confirm `used_memory` is at/near `maxmemory`. Note the `maxmemory_policy` (often 'noeviction' by default if not otherwise set).
+          - `INFO COMMANDSTATS`: Observe `rejected_calls` for write commands.
+
+        RECOVERY STEPS:
+        1. **Increase `maxmemory` (if feasible):** `CONFIG SET maxmemory <new_size_bytes_or_mb_gb>`. This is often the safest first step if resources allow, to provide immediate relief without data loss.
+        2. **Manual Data Deletion:** If specific non-essential data can be identified, use `DEL <key_name> ...` to free up memory. This requires knowledge of the data.
+        3. **Evaluate and Consider Changing `maxmemory-policy` (Use with Caution):**
+           - If the current policy prevents eviction (e.g., 'noeviction', which is often the default when `maxmemory` is set) and writes must be restored quickly, consider changing to an eviction policy (e.g., `allkeys-lru`, `volatile-lru`, `allkeys-random`).
+           - **WARNING: Enabling an eviction policy WILL lead to Redis deleting keys** to stay under the `maxmemory` limit when new data is written.
+           - **Action:** Only proceed if the potential loss of some data (as determined by the chosen eviction strategy) is an acceptable trade-off to restore write availability. Thoroughly understand the behavior of different [Redis eviction policies](https://redis.io/docs/latest/operate/oss_and_stack/management/memory-optimization/#eviction-policies) before choosing one.
+           - Command: `CONFIG SET maxmemory-policy <chosen-eviction-policy>`
+        4. **Analyze & Optimize Application:** Investigate sources of high memory usage; optimize data structures, reduce data footprint, or change write patterns.
+        5. **Scale Redis Instance:** If memory pressure is persistent, provide more memory to the Redis server or consider migrating to a clustered solution.
+
+        PREVENTION:
+        - **Capacity Planning:** Set `maxmemory` based on careful estimation of workload and available resources, including a buffer for growth and spikes.
+        - **Informed `maxmemory-policy` Selection:**
+          - Consciously choose and configure a `maxmemory-policy` that aligns with your application's data access patterns, the importance of data persistence versus write availability, and your tolerance for data loss.
+          - Understand the implications of `noeviction` (default when `maxmemory` is set) versus various eviction strategies. Do not rely on defaults without understanding them.
+        - **Comprehensive Monitoring & Alerting:**
+          - Alert when `used_memory` approaches `maxmemory` (e.g., >80-85%).
+          - Monitor `rejected_commands` (if the policy is non-evicting) or `evicted_keys` (if an eviction policy is active).
+          - Monitor client-side error rates from Redis.
+        - **Use Time-To-Live (TTLs):** Set expirations on keys that do not need to persist indefinitely to help manage memory proactively.
+        - **Client-Side Error Handling:** Implement robust error handling in applications (e.g., retries with backoff, circuit breakers, fallback mechanisms) for Redis OOM conditions or other errors.
+      mitigationScore: 6 # Score might be slightly lower due to complexity/risk of some mitigations
+      references:
+        - "https://redis.io/docs/latest/operate/oss_and_stack/management/optimization/memory-optimization/"
+        - "https://redis.io/docs/latest/operate/rs/databases/memory-performance/memory-limit/"
+        - "https://redis.io/docs/latest/operate/rs/databases/memory-performance/eviction-policy/"
+      applications:
+        - name: "redis"
+          version: "*"
+    metadata:
+      kind: "prequel"
+      id: "HcYe7N3XHfKLYNoWn8wQYL"
+    rule:
+      set:
+        event:
+          source: cre.log.redis-cli
+        match:
+          - regex: "OOM command not allowed when used memory > 'maxmemory'"

--- a/rules/cre-2025-0071/test.log
+++ b/rules/cre-2025-0071/test.log
@@ -1,0 +1,1 @@
+2025-06-01 01:23:14 OOM command not allowed when used memory > 'maxmemory'. script: cb827dabea2a23ef3e22d2d1adaf1ee278fc48d9, on @user_script:1.


### PR DESCRIPTION
**Summary**

This PR introduces a new CRE (Common Remediation Enumeration) detection rule for a common and critical Redis failure. The failure occurs when a Redis instance reaches its configured `maxmemory` limit and, due to its active memory management policy (typically 'noeviction', which is often the default), begins rejecting client write commands.

Closes #42

**Rule Added**

* **Title:** Redis Rejects Writes Due to Reaching 'maxmemory' Limit
* **ID:** CRE-2025-0071
* [PlayGround Link](https://play.prequel.dev/?data=EwBmFYFoQNmhGABCeAuYBmV8AsiDy%2BAsogMYD2AtpQIYB2AJoneQC6I0A2n5A7gKZNeAC351EAVwDOgxJX6VyAJwCeiAHyIA5LQAe8xaq0A6RFNJKAlgAdWqMgCMAHMADsDGg-41gPjPwAzf2BgBlD4Gg8A%2BH5%2BNycA0hwnBgBOABpEcnEAAWl%2BJQB9cytbbGMAKCA&rule=E4VwNgpgzgXAUAAgQWgQY2BeScIJYAmMCAwgEoCiyATAAzUCsyttA7AIyK4JQQBuEYHgAuAT2KduCYSMjEARGQgE8UBEoBWENMLUB1IcOgIAIiAjSA9uogBDNAAs8AOwDmCAOQBbWwA8vEF6WwKIeCAAyeF4i8ly4aLZGrsHiCPIEibYARra8yAAOwJZZkF6xUrYgwg7BCgCCzgSYCACyVbbl3ATQGHj5MpbOxAA%2BcdwAKg4WSipqLlDCts5oFg65CJj2UwT4uuiDAGZ4riCYO95%2BAUEhYWBRIgB0CABC2pW8u2r2MgIIVyljXA%2BZy2VyBCDOYQIfKWO5oUQIAiWYzOSxQ-KCaJQ6oWfh4HR4QYISwHBAQXyqGRuBAAawgojUwmsB0wFhA%2BR4%2BXsFgAFOtVNIpoCcAkPgB3KbOQUWDyovEEwZhGFwhEClxkg4HbTCAA0CAl%2BIc%2BDUJKMUpxiIgB0qYGEAEo9TMBZgtDooMKkM4IGL9YYLGhLF5gQQ1FkEbxGi53Es0gB5WMtfZBpY7VFQ2xgMCWMXKeRk4BFYBWaXoO4Q4QPYUJEC8EYelA2WaeHz%2BQIpW73KFrUMQCEbOyOZSVqRIVCTCzfPC-f4hP5LUHgyHQ2H4hGFfjltR0hHygbm6w%2BOmc7kIHkQB6uB562XIvj4vdKlfw40ISe-MOW63gKHBfbOI4nMAiSEs4drDiOqB1Pk%2BRwsBRKJEYXj9FGxZin6iKZGSvgrMoKEWrYfC2HgYDZJAzaXG2NzgbgURcjodYjg25AAJLjMxJB1OExDMSCWTESICJMr6IgWF6PoZIsxJFkEKgHAiEm2PgUqKWKtiCWsUIuBgdi8GoM4IjWC7UdwqAAApouWeAZhhklZlAcykr0MgJGASkBtE1JoSJXzNGmCBrI0kA7B%2BaBlkutjQbBe5QMZuCoAAyoId4rJarhARJIFSQg1rEacFgHL%2BEUwficFSu5MJepCajdBijTlsSUpOmoXlGDFwq0d88UBpgxAAJzCosriwPWqBnKoI39rMyChXgE2WIGE0tvpi2UaIyB3FiE0tRAyA5WAeXClixylQxI7MS0LQUCYzF1OMFAIHUJBsbGABy8XYBBCAAFRfQAaoIeByaQYVQhQBbBLAP2kFMaA0q%2BkUlXuCBZkN2W-vIZ7g8AdoIPGibucGCB%2BRmWY5jsEp9jWyh-KtCAAHzka21yhHmAT2QubWMagP0kDDcNNQg8WLEYp4AAZjVA013KLdowD99ajggovMS9ABisY08zovECQhx4MAXhK1TBAAPr6aLL6JAA9F6thFqLS2raLTwvRZJYOxRzMm8qq4Wzypp9jeu4gWEH7dF%2Btr4KSflolMwBiqoFi8PasUmUrKvq6QCYtHUL0mPF4y3fF2u41kvDAL84sQK6Rimy5YBQBbBVFttSbBm19aUCQsa-RQZAAJqC3dpnvfW7BPD9PHabkFge0zKR%2B4D2U6XgJQQLLUOi93avMQA4oLFDjHO8%2BzgAPGJJtQHgABeEAm2GrUm8EZtZCbrhZHTzsIJMaomgcZoligLYLUCxsr61AQsCAHIl6YCgJYU4KwviZmzHqIShRLB3m6PgIMuFEgWEwGWUkCdqjwKhApZGlh7KpyQNQCeX0WhLBANZEwmETAQEgHuOWX0EDMVJFADEaBAb4iJoMZA0AIwyGsuQhIUosgWEIJZI4yg9RUyViYCg4QECn23CbEEAQGYPEMRbISLJewIHZJrFITwf5qEwAARxAPrYwNJURiiCmCYkpILQKWoQgAAzHQighF9p4NfI0Uggwr7dCLLzJYrgUJz30gUJ8og-YAFVxQiCNCQSoe4N5fQVorXhJY0CnEwEuH2z51wCCqmSZKSMzwXivJ4OU9SQ56gNI4F8AdzRTE-DaKEFMpSJKdi%2BZOOMUzCVan8GsUI5H9gWMEamDj8Q0jAKIPUAZnBRMEOgAK8TqRCRjMHIklSESNMvHqUWJNtySzAKAUWVy%2BCwmApAdaDyrk3PpJLICjRAwy18TgbmX09B1DIC9FWu9iAUF4ncakxy2mnJSQgPQzFwiaMgLYHYQkBbdA4ShW5UMhILDUuYuqRYLQjK1sjTs%2BpJRE29DZRSAoWpmkBYrH6dQFRDChrGZw6zoRFBwjsJeFoYRmkka5Oyf8eCBgsOQvk1UIBGANi4amH4LSOEoX2E5UoFhASSKIHGAoYz2BWP0UiFhhDpR2iSLx1hYFMmaK3AiRESJ8TuGIaxNQiggFcA4AVIByUkvCRaORaw7y-hJIiQGWpylQgANoC11cuOEeBoAAF0eQOGEMIfIsArZWwlg8QkVskRoCgFbEirVhBW0sBiA1EA632RNimS%2BixYZW2BAuAIkIu2rWQPWmQ0Rr6lStgAYl1cktN0AcZyObv6GolCUKDHPIUpigZgzEC3q9VWe8D5H0dszadq4tFaojGIxFzgT3wk-vWAALHQhoGZRC3wQAAMlxshEdFgoLFQSJwqGPEBALGOiLOBCDjDRqcP6yxs5DJggANzEm-TfeVmF9UgB0HlKAeozhYfQ5JAqaJCguF1FlRwcSLCty5LmwQ2zfEMDoV1DM0xcJqB4iGlYXCeGkn0oK8ReUXwNqvpAyEep0GYIsNcaTtMhIWgFuXAQRZfxbJ2dJY4Bq8LWEUqFWZghqZwP2nuSsh0RBgZAl1JZxAABsCBx2C26tJ44OaEDzKgHcf1wgBWk12QQcwxZyqQApGIItqg4bRrgQEP45nXClXdFITAcaISII%2BlIVA8gc15oLUW9jJbLBlssBWqteCFh1obXg5tUBW2NHbfYGkXb5xgl7bWod9xR17n7cetrI6x2dHS2kLL%2BaYCFuLaW8tlbq3QFaxVowRbK0KRyLpLrKQCiCGbsCFYK2QjrU7FbfradMu5uG6NvL42iuTdKzNwQlXgALcyEt6A221oNo20sLbU6zn7eFEVKKIFhpcyJrYAICgJYHakMpq%2BgwFBfQOwERYCk0s4BpC4IgaR1wOPYeD-AaP5AAAk0D9wgKwF6fiAAaeODgAGlwj91dnoZwAAOMUABFfu4QDugDkMKZOSPcAbkhHz7gEHgDcfQJgB4KMHgSylrNRiPhhCOCF3FfsYJfAKDxm3SZxNkFkzpZTXgOx%2BMMwuCfFmQA)

**Failure Scenario Details**

The rule is designed to detect the specific error message `(error) OOM command not allowed when used memory > 'maxmemory'` that Redis sends to clients under these conditions. This indicates that the server cannot allocate memory for new write operations and is not configured to evict existing keys to make space.

**Video Demonstration**

https://github.com/user-attachments/assets/20b90536-9917-46da-b566-0a38aa0decb8

**Reproduction Environment & Logs**

A complete, minimal setup to reproduce this failure scenario is available in a separate GitHub repository:

➡️ **Reproduction Repository:** `https://github.com/amuta/cre-2025-0071-setup

This repository includes:
* `docker-compose.yml` to set up the Redis instance with appropriate `maxmemory` limits.
* `run_oom_test.sh` script to trigger the OOM condition by writing data.
* `test.log` which contains example logs. **Crucially, `test.log` captures the timestamped output directly from the `redis-cli` client, demonstrating the exact error message as an application would receive and log it.**

**Detection Logic within the Rule**

The CRE rule identifies this failure by using a regular expression to match the distinct error string `"OOM command not allowed when used memory > 'maxmemory'"` within logs originating from applications or clients interacting with Redis