### PR TITLE
New Rule: CoreDNS Unavailable

### DIFF
--- a/rules/cre-2025-0071/coredns-unavailable-dns-outage.yaml
+++ b/rules/cre-2025-0071/coredns-unavailable-dns-outage.yaml
@@ -17,13 +17,11 @@ rules:
       author: "Nicolas Yarosz"
       description: >
         CoreDNS deployment is unavailable or has no ready endpoints, indicating
-        an imminent cluster-wide DNS outage. This detects the failure BEFORE
-        DNS queries start timing out, providing critical early warning.
+        an imminent cluster-wide DNS outage.
       impact: >
         When CoreDNS becomes unavailable, all service discovery fails, readiness
         probes that rely on DNS begin to fail, pods cycle in and out, and the
-        entire cluster can grind to a halt. This is a commonly cited root cause
-        in production Kubernetes outage post-mortems.
+        entire cluster can grind to a halt.
       impactScore: 9
       cause: >
         CoreDNS deployment scaled to zero replicas, pods crashed due to bad

--- a/rules/cre-2025-0071/coredns-unavailable-dns-outage.yaml
+++ b/rules/cre-2025-0071/coredns-unavailable-dns-outage.yaml
@@ -1,0 +1,60 @@
+rules:
+  - metadata:
+      id: 3XWJJQRXwFVG1aJPammi5j
+      hash: CAbgxyQnLLP12A6GrRHAdcBsbtstGio1gEAj3kLqyRe9
+      generation: 1
+      kind: prequel
+    cre:
+      id: CRE-2025-0071
+      severity: 1
+      title: "CoreDNS unavailable - DNS outage imminent"
+      category: "kubernetes-problem"
+      tags:
+        - "kubernetes"
+        - "networking"
+        - "dns"
+        - "high-availability"
+      author: "Nicolas Yarosz"
+      description: >
+        CoreDNS deployment is unavailable or has no ready endpoints, indicating
+        an imminent cluster-wide DNS outage. This detects the failure BEFORE
+        DNS queries start timing out, providing critical early warning.
+      impact: >
+        When CoreDNS becomes unavailable, all service discovery fails, readiness
+        probes that rely on DNS begin to fail, pods cycle in and out, and the
+        entire cluster can grind to a halt. This is a commonly cited root cause
+        in production Kubernetes outage post-mortems.
+      impactScore: 9
+      cause: >
+        CoreDNS deployment scaled to zero replicas, pods crashed due to bad
+        configuration, or underlying infrastructure issues causing CoreDNS
+        pods to become unready or unavailable.
+      mitigation: >
+        **Immediate Actions:**
+        - Check CoreDNS deployment status: `kubectl -n kube-system get deployment coredns`
+        - Verify CoreDNS pod health: `kubectl -n kube-system get pods -l k8s-app=kube-dns`
+        - Check CoreDNS logs: `kubectl -n kube-system logs -l k8s-app=kube-dns`
+        
+        **Common Fixes:**
+        - Scale deployment if replicas are 0: `kubectl -n kube-system scale deploy/coredns --replicas=2`
+        - Restart pods if configuration issues: `kubectl -n kube-system rollout restart deployment/coredns`
+        - Verify kube-dns service endpoints: `kubectl -n kube-system get endpoints kube-dns`
+      mitigationScore: 8
+      references:
+        - "https://kubernetes.io/docs/tasks/administer-cluster/dns-debugging-resolution/"
+        - "https://coredns.io/manual/toc/#troubleshooting"
+      reports: 0
+      version: "0.1.0"
+      applications:
+        - name: "coredns"
+          processName: "coredns"
+          version: "*"
+        - name: "kubernetes"
+          processName: "kubelet"
+          version: "v1.29+"
+    rule:
+      set:
+        event:
+          source: cre.log.kubernetes
+        match:
+          - regex: "Scaled down replica set coredns-.+ from [1-9]+ to 0|Stopping container coredns|Readiness probe failed.+connection refused" 

--- a/rules/cre-2025-0071/coredns-unavailable-dns-outage.yaml
+++ b/rules/cre-2025-0071/coredns-unavailable-dns-outage.yaml
@@ -7,7 +7,7 @@ rules:
     cre:
       id: CRE-2025-0071
       severity: 1
-      title: "CoreDNS unavailable - DNS outage imminent"
+      title: "CoreDNS unavailable"
       category: "kubernetes-problem"
       tags:
         - "kubernetes"

--- a/rules/cre-2025-0071/test.log
+++ b/rules/cre-2025-0071/test.log
@@ -1,0 +1,3 @@
+2025-06-01T17:16:37Z Normal ScalingReplicaSet deployment/coredns Scaled down replica set coredns-674b8bbfcf from 2 to 0
+2025-06-01T17:16:37Z Normal Killing pod/coredns-674b8bbfcf-dgnrh Stopping container coredns
+2025-06-01T17:16:40Z Warning Unhealthy pod/coredns-674b8bbfcf-dgnrh Readiness probe failed: Get "http://10.244.0.58:8181/ready": dial tcp 10.244.0.58:8181: connection refused


### PR DESCRIPTION
### Details
/claim #41 

* **Reproducible test setup**: Uses kind cluster with CoreDNS scaling reproduction
* **Test data in a test.log file**: Real CoreDNS failure timeline with early warning signals
* **CRE Rule**: CRE-2025-0071 - CoreDNS unavailable detection with severity 1 (high)
* **Local Testing**: ✅ Verified with preq CLI - rule fires correctly on all patterns

### CRE Details
- **CRE ID**: CRE-2025-0071
- **Severity**: 1 (High) 
- **Impact Score**: 9/10
- **Title**: CoreDNS unavailable
- **Category**: kubernetes-problem

### Problem Detection
This rule provides **early warning** for CoreDNS failures by detecting:
1. **Scaling to zero**: `Scaled down replica set coredns-.+ from [1-9]+ to 0`
2. **Container termination**: `Stopping container coredns`  
3. **Readiness probe failures**: `Readiness probe failed.+connection refused`

### Why This Matters
CoreDNS unavailability is a critical failure that can break all service discovery in the cluster, cause cascading readiness probe failures, lead to complete cluster outage, and is commonly cited in production post-mortems.

### Commands for Sample Data
*A full reproduction repo is available [here](https://github.com/yarosz/k8s-coredns/invitations) with a README and script that automates the below simplified commands*

The `test.log` file associated with **CRE-2025-0071** was generated by reproducing CoreDNS failure scenarios. The core commands executed to produce the log entries are:

**1. To reproduce CoreDNS scaling failure:**
```shell
# Scale CoreDNS to zero (triggers immediate detection)
kubectl -n kube-system scale deployment/coredns --replicas=0

# Capture the scaling event
kubectl -n kube-system get events --sort-by=.lastTimestamp | grep coredns
```

**2. To capture readiness probe failures:**
```shell  
# Monitor pod termination and readiness failures
kubectl -n kube-system get events --watch --field-selector reason=Killing,reason=Unhealthy | grep coredns
```

**3. To collect timeline for test.log:**
```shell
# Collect events with timestamps
kubectl -n kube-system get events --sort-by=.lastTimestamp -o custom-columns=TIME:.lastTimestamp,TYPE:.type,REASON:.reason,OBJECT:.involvedObject.name,MESSAGE:.message | grep coredns
```

The `test.log` contains real failure events that demonstrate how this rule detects CoreDNS unavailability **before** DNS queries start timing out, providing critical early warning for cluster-wide DNS outages.

### Video

https://github.com/user-attachments/assets/e07ed205-2354-4124-8c7d-7d01d56a0ade


