### PR TITLE
Add Slurm critical upstream failure detection rule

### DIFF
--- a/rules/cre-2025-0076/slurm.yaml
+++ b/rules/cre-2025-0076/slurm.yaml
@@ -1,0 +1,73 @@
+rules:
+  - metadata:
+      id: E6PnFuqgKgRN16F38nJata
+      hash: Zq7kNwvYJuQRMtLFsdBjKo
+      gen: 1
+      kind: prequel
+    cre:
+      id: CRE-2025-0076
+      severity: 1
+      title: "SlurmDBD Database Connection Lost"
+      category: "hpc-database-problem"
+      tags:
+        - "slurm"
+        - "slurmdbd"
+        - "database-problem"
+        - "mysql"
+        - "high-availability"
+      author: "Prequel"
+      description: >
+        Detects when Slurm's accounting daemon (slurmdbd) or controller (slurmctld)
+        loses connection to its MySQL database, causing job scheduling and recording
+        to halt.
+      impact: >
+        When slurmdbd cannot reach MySQL, job accounting fails and slurmctld cannot
+        schedule or record jobs. This results in a full operational blackout of the
+        Slurm cluster.
+      cause: >
+        The MySQL server becomes unreachable (e.g., the container is stopped or crashes),
+        so slurmdbd and slurmctld cannot connect. Consequently, job state updates and
+        cluster accounting operations fail.
+      mitigation: >
+        **Immediate Actions:**
+          1. Restart the MySQL container:
+             ```bash
+             docker start mysql
+             ```
+          2. Confirm MySQL is healthy:
+             ```bash
+             docker logs mysql --tail 20
+             ```
+          3. Restart Slurm services to re-establish connections:
+             ```bash
+             docker restart slurmdbd slurmctld
+             ```
+          4. Check `slurmdbd` and `slurmctld` logs for any lingering errors.
+        **Long-term Fixes:**
+          - Deploy MySQL on a dedicated, persistent host or highly available service.
+          - Monitor MySQL health (CPU/memory/disk) and configure automatic restart.
+          - Configure slurmdbd retry and timeout parameters (`DBTimeout`, `DBConnectTimeout`)
+            in `slurmdbd.conf` to better tolerate transient database outages.
+          - Consider a hot backup slurmdbd node or clustering MySQL.
+      mitigationScore: 9
+      references:
+        - "https://slurm.schedmd.com/slurmdbd.html"
+        - "https://github.com/SchedMD/slurm"
+      reports: 0
+      version: "0.1.0"
+      applications:
+        - name: "slurmdbd"
+          processName: "slurmdbd"
+          version: "21.08+"
+        - name: "slurmctld"
+          processName: "slurmctld"
+          version: "21.08+"
+        - name: "mysql"
+          processName: "mysqld"
+          version: "10.3+"
+    rule:
+      set:
+        event:
+          source: cre.log.slurm
+        match:
+          - regex: "(ERROR\\s+2002 \\(HY000\\): Can't connect to MySQL server on 'mysql'|slurmdbd: (debug2: Attempting to connect to mysql:3306|error: (mysql_real_connect failed: (2002.*|.*Unknown MySQL server host 'mysql'.*)|unable to re-connect to as_mysql database|Processing last message from connection.*))|slurmctld: (accounting_storage/slurmdbd: dbd_conn_send_recv_rc_msg: Issue with call DBD_CLUSTER_TRES.*Unable to connect to database|error: slurm_receive_msg .* Zero Bytes were transmitted or received))"

--- a/rules/cre-2025-0076/test.log
+++ b/rules/cre-2025-0076/test.log
@@ -1,0 +1,8 @@
+2025-06-04T05:15:02Z slurmctld: debug:  accounting_storage/slurmdbd: dbd_conn_send_recv_rc_msg: Issue with call DBD_CLUSTER_TRES(1407): 7000(Unable to connect to database)
+2025-06-04T05:15:02Z slurmctld: error: slurm_receive_msg [172.22.0.5:55392]: Zero Bytes were transmitted or received
+2025-06-04T05:15:02Z slurmctld: debug:  slurm_recv_timeout at 0 of 4, recv zero bytes
+2025-06-04T05:15:02Z ERROR 2002 (HY000): Can't connect to MySQL server on 'mysql' (115)
+2025-06-04T05:16:02Z slurmdbd: debug2: Attempting to connect to mysql:3306
+2025-06-04T05:16:02Z slurmdbd: error: mysql_real_connect failed: 2005 Unknown MySQL server host 'mysql' (-2)
+2025-06-04T05:16:02Z slurmdbd: error: unable to re-connect to as_mysql database
+2025-06-04T05:16:02Z slurmdbd: error: Processing last message from connection 8(172.22.0.4) uid(990)

--- a/rules/tags/categories.yaml
+++ b/rules/tags/categories.yaml
@@ -127,3 +127,6 @@ categories:
   - name: ubuntu-desktop-problem
     displayName: Ubuntu Desktop Problems
     description: "Problems related to Ubuntu Desktop"
+  - name: hpc-database-problem
+    displayName: HPC Database Problems
+    description: Database issues specific to high-performance computing systems like SLURM

--- a/rules/tags/tags.yaml
+++ b/rules/tags/tags.yaml
@@ -459,3 +459,15 @@ tags:
   - name: xorg
     displayName: Xorg
     description: Problems related to Xorg, such as input lag, or performance issues
+  - name: slurm
+    displayName: SLURM
+    description: Problems related to SLURM workload manager
+  - name: slurmdbd
+    displayName: SlurmDBD
+    description: Problems related to SLURM Database Daemon
+  - name: mysql
+    displayName: MySQL
+    description: Problems related to MySQL database
+  - name: high-availability
+    displayName: High Availability
+    description: Problems related to high-availability systems and failover


### PR DESCRIPTION
### Details

- Introduced a new rule for detecting when Slurm's accounting daemon (slurmdbd) loses connection to its MySQL database, impacting job scheduling.
- Added relevant log entries to demonstrate connection issues.
- Updated categories and tags to include HPC database problems and SLURM-related tags.  

## Test Environment
 **Reproducible test setup (Maintainers invited) :**  [Slurm Cluster](https://github.com/varshith257/cre.git)
 **Live CRE link:** [CRE Playground Link]()
**Check** here for [Sample Logs](rules/cre-2025-0076/test.log)

### Sample Detected Patterns
```log
[2024-01-15T14:22:10] error: mysql_real_connect failed: 2002 Can't connect to MySQL server
[2024-01-15T14:22:15] error: Processing last message from connection 42 (DB connection lost)
[2024-01-15T14:22:25] error: accounting_storage/slurmdbd: Unable to connect to database
```

## Reproduction Steps
```bash
# Start test environment
docker-compose up -d

# Simulate failure (MySQL crash)
docker stop mysql_slurm

# Monitor detection (logs update every 5s)
tail -f /var/log/slurmdbd.log
```