### PR TITLE
Add rules for CUDA out of memory issues in Stable Diffusion WebUI and…

### DIFF
--- a/rules/cre-2025-0140/sd-webui-oom.yaml
+++ b/rules/cre-2025-0140/sd-webui-oom.yaml
@@ -1,0 +1,72 @@
+rules:
+  - cre:
+      id: CRE-2025-0140
+      severity: 1
+      title: Stable Diffusion WebUI CUDA Out of Memory during batch processing
+      category: memory-problem
+      author: Prequel
+      description: |
+        Stable Diffusion WebUI encounters a CUDA out of memory (OOM) error during batch image generation,
+        causing the entire generation pipeline to crash. This typically occurs when the batch size or image
+        dimensions exceed available VRAM capacity, particularly on consumer GPUs with limited memory.
+      cause: |
+        The root cause is attempting to allocate more VRAM than available for tensor operations during
+        the cross-attention computation phase. Common triggers include:
+        - Batch size set too high for available VRAM
+        - High resolution images (1024x1024 or larger) without optimization flags
+        - Multiple ControlNet or LoRA models loaded simultaneously
+        - Insufficient use of memory optimization options (--medvram, --lowvram)
+      impact: |
+        - Immediate termination of the generation pipeline
+        - Loss of all in-progress image generations in the batch
+        - Potential corruption of partially generated images
+        - API endpoints return error responses, breaking automation workflows
+        - System requires manual intervention to recover
+      impactScore: 8
+      mitigation: |
+        Immediate fixes:
+        1. Reduce batch size (set to 1-2 for consumer GPUs)
+        2. Enable memory optimization flags:
+           - Use --medvram for 6-8GB VRAM GPUs
+           - Use --lowvram for 4-6GB VRAM GPUs
+           - Use --no-half for CPU fallback
+        3. Reduce image dimensions to 512x512 or 768x768
+        4. Enable attention slicing with --xformers or --opt-split-attention
+        5. Clear VRAM before generation: torch.cuda.empty_cache()
+        
+        Long-term solutions:
+        - Implement dynamic batch size adjustment based on available VRAM
+        - Add pre-flight VRAM checks before starting generation
+        - Upgrade to GPU with more VRAM (16GB+ recommended)
+      mitigationScore: 3
+      tags:
+        - stable-diffusion
+        - cuda
+        - gpu
+        - memory-leak
+        - batch-processing
+        - pytorch
+        - webui
+        - automatic1111
+      references:
+        - https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Optimizations
+        - https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/8035
+        - https://pytorch.org/docs/stable/notes/cuda.html#memory-management
+      applications:
+        - name: stable-diffusion-webui
+          version: ">= 1.0.0"
+        - name: pytorch
+          version: ">= 2.0.0"
+    metadata:
+      kind: prequel
+      id: SEKbLKEnpyQo2mkKvFZYXo
+      gen: 1
+    rule:
+      set:
+        window: 10s
+        event:
+          source: cre.log.sdwebui
+        match:
+          - regex: 'CUDA out of memory\. Tried to allocate .* GiB'
+          - regex: 'torch\.cuda\.OutOfMemoryError: CUDA out of memory'
+          - value: 'Generation failed: Out of memory error'

--- a/rules/cre-2025-0140/test.log
+++ b/rules/cre-2025-0140/test.log
@@ -1,0 +1,36 @@
+2025-08-27 22:44:48,804 - INFO     - [modules.shared] - Loading config from: /home/user/stable-diffusion-webui/config.json
+2025-08-27 22:44:48,804 - INFO     - [modules.shared] - Command line args: Namespace(batch_size=8, medvram=False, lowvram=False)
+2025-08-27 22:44:48,804 - INFO     - [modules.sd_models] - Loading model from cache: v1-5-pruned-emaonly.safetensors
+2025-08-27 22:44:48,804 - INFO     - [modules.devices] - CUDA available: True, Device: cuda:0 (NVIDIA GeForce RTX 3090)
+2025-08-27 22:44:48,804 - INFO     - [modules.devices] - Total VRAM: 24576 MB, Available: 18432 MB
+2025-08-27 22:44:48,804 - INFO     - [modules.txt2img] - Starting batch generation: 8 images, 512x512, steps: 20
+2025-08-27 22:44:48,904 - WARNING  - [modules.devices] - High VRAM usage detected: 22528 MB / 24576 MB (91.7%)
+2025-08-27 22:44:48,905 - INFO     - [modules.processing] - Processing batch 1/8...
+2025-08-27 22:44:48,905 - WARNING  - [torch.cuda] - Allocated memory: 23.5 GB, Reserved: 24.0 GB
+2025-08-27 22:44:48,905 - INFO     - [modules.processing] - Processing batch 2/8...
+2025-08-27 22:44:48,905 - WARNING  - [modules.devices] - VRAM usage critical: 24064 MB / 24576 MB (97.9%)
+2025-08-27 22:44:49,005 - INFO     - [modules.processing] - Processing batch 3/8...
+2025-08-27 22:44:49,005 - ERROR    - [torch.cuda] - CUDA out of memory. Tried to allocate 2.00 GiB (GPU 0; 24.00 GiB total capacity; 22.50 GiB already allocated; 512.00 MiB free; 23.00 GiB reserved in total by PyTorch)
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] - RuntimeError: CUDA out of memory during cross-attention computation
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] - Traceback (most recent call last):
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] -   File "modules/processing.py", line 732, in process_images_inner
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] -     samples = sampler.sample(p, x, conditioning, unconditional_conditioning)
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] -   File "modules/sd_samplers_kdiffusion.py", line 234, in sample
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] -     samples = self.launch_sampling(steps, lambda: self.func)
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] - torch.cuda.OutOfMemoryError: CUDA out of memory
+2025-08-27 22:44:49,005 - CRITICAL - [modules.shared] - Generation failed: Out of memory error
+2025-08-27 22:44:49,005 - ERROR    - [modules.api.api] - API error: {'error': 'OutOfMemoryError', 'detail': 'CUDA out of memory. Try reducing batch size or image dimensions'}
+2025-08-27 22:44:49,005 - WARNING  - [modules.devices] - Attempting VRAM cleanup...
+2025-08-27 22:44:49,005 - INFO     - [torch.cuda] - Clearing cache and collecting garbage
+2025-08-27 22:44:49,005 - ERROR    - [modules.processing] - Batch processing interrupted at item 3 of 8
+2025-08-27 22:44:49,005 - ERROR    - [modules.ui] - Generation failed after processing 2 images
+2025-08-27 22:44:49,105 - INFO     - [modules.devices] - Attempting automatic recovery...
+2025-08-27 22:44:49,105 - INFO     - [torch.cuda] - torch.cuda.empty_cache() called
+2025-08-27 22:44:49,105 - INFO     - [modules.shared] - Reducing batch size from 8 to 4
+2025-08-27 22:44:49,105 - WARNING  - [modules.processing] - Restarting generation with reduced settings
+2025-08-27 22:44:49,105 - INFO     - [modules.devices] - VRAM after cleanup: 8192 MB available
+2025-08-27 22:44:49,105 - INFO     - [modules.devices] - CUDA available: False, Using CPU mode
+2025-08-27 22:44:49,105 - INFO     - [modules.processing] - Processing on CPU, no VRAM limitations
+2025-08-27 22:44:49,105 - WARNING  - [modules.shared] - High RAM usage: 28 GB / 32 GB
+2025-08-27 22:44:49,105 - INFO     - [modules.processing] - Successfully completed batch 8/8
+2025-08-27 22:44:49,106 - INFO     - [modules.txt2img] - Generation complete: 8 images generated

--- a/rules/tags/tags.yaml
+++ b/rules/tags/tags.yaml
@@ -845,3 +845,24 @@ tags:
   - name: cluster-scaling
     displayName: Cluster Scaling
     description: Problems related to Kubernetes cluster scaling operations and capacity management
+  - name: stable-diffusion
+    displayName: Stable Diffusion
+    description: Issues related to Stable Diffusion image generation models
+  - name: automatic1111
+    displayName: AUTOMATIC1111 WebUI
+    description: Problems specific to the AUTOMATIC1111 Stable Diffusion WebUI
+  - name: webui
+    displayName: Web UI
+    description: Issues with web user interface components
+  - name: batch-processing
+    displayName: Batch Processing
+    description: Problems occurring during batch job processing
+  - name: cuda
+    displayName: CUDA
+    description: NVIDIA CUDA GPU computation issues
+  - name: gpu
+    displayName: GPU
+    description: Graphics Processing Unit related problems
+  - name: pytorch
+    displayName: PyTorch
+    description: Issues related to PyTorch deep learning framework


### PR DESCRIPTION
# CRE-2025-0140: Stable Diffusion WebUI CUDA Out of Memory Detection

## Overview

This pull request implements a Critical Runtime Event (CRE) detection rule for Stable Diffusion AUTOMATIC1111 WebUI CUDA out of memory errors during batch processing. The rule identifies critical failures where GPU memory exhaustion causes complete generation pipeline crashes.

## Problem Statement

Stable Diffusion WebUI systems can experience critical CUDA out of memory errors during batch image generation, creating scenarios where:

- GPU memory allocation fails during tensor operations
- Entire batch processing pipelines crash mid-execution
- Generated images are lost without proper error handling
- API endpoints fail with memory-related errors
- Production workflows are interrupted requiring manual intervention

## CRE Playground Links

[Playground Link](https://play.prequel.dev/?data=EwBmFYFoQDk4DsACYwBcAWDmYBoYgZKRICSAcgGIDySddJA2gLYD2AJgK4A2ApgM4A6fgAsAhgCde7ALrEkAGVZj2ASwB2AcyQBjVuoBmq7QYmtmaJAHoR53lc79eEq-wAuYgEZ9IagwcdVfUgAd15PTlUrPUNjQQArfn0AKFAIaDhEFHQsHHxCeQoaegYkFg4eAWFxKVl5AGFzZjF1diRuDV4kSU1%2BS3IxZgEABzEdXgAKTzE3HREAfX5VAC9eAF48JCH2ADcJQbXKMW4nXHbWEL2Do5PeAEpUsChYeGRUTGwMPAIiEiLaEpMNhcPhCfjsebA3gnOQkJQqDTaKHcJCmcy6MYiXiWHYARkgUGGEk46mkkF4zX03AAnsIxAZeG5eOokhJ%2BI90i8su9cl98r8yFQAfQgRVQYJ2LwdqpxvxYUh6gBVAAiAEFujsxKpuF4%2BJYACrE3hnZVSmXY3ScdhiNAgJATcgANVIytI6oA4rxKKwJOMkAAlfUADSQAGYQABOEAPNLPTJvHKfb4FP5CkrycogqqS6Wy%2BX61geFGO-2qgCylmAGHACAAbEgywAhM6qzXa3UW3EwDCh4ANxscuOvbIfPI-QppwFlYGVIRuAAebmAqmYmnlAGUPBI3IikNNZiIkJpmc4ZkF1JYYEgV2Jj-wzuBccB54-gGd3Lxhn0UCBBxlhzySa4FGAoAOqqv65AUO6pSZrOEpmnm8gABLGIeJblkgji3l0kpMjoTLsJWEDAFeTbWCg1Z1v29oRriggIAApDGTz-tyiZ5FG4ATsUU5weKRKsLKSxaPKAAKZjCbu%2B5zEguJWDAghKX%2BXIJqOfJcfI4GQdBsFuD6cyCDoVpiPKqrcNwQkzNIWwUj61KVqGgjce6zYBgIzg7NIlYYIIdquSp8YjryeCaamvEitOYpVIJUmifIElCQIInaDJh7AApSmCIFAEcRpIDcSQ2lQeQMEZjO4o5uacryBhZZYfwOG6BIqg7joxw%2BSAtZEORViUTW9bkRMEYIIIEbMTl7HqRGuAgAVPHCrBFUxZJyWIuJq38Cle4zLJoaZcpsZsWpvIzXNhVIAAov6-rUP6fH6b6IhGSZ8pKmqSCsJwbifQYtlsBItJIIaqg2fp3QWVZTIoH5-mqI29rumJipICAADclGw0g7rw0g%2BlFhiow6K11IY6gzlwwjxxSCo1IQ5Z7WERjr5Y2WuOmLwvBk05c3Y7jUhOBIXltBoeOFsce502J1IFk9LGckFgGYGd80kNdt33ZF-ErUlW3rfI-okjuQyXRIZgSJY73ql9P2sH9QwA3TXAtVozWsFtkAzEy6g7voujmMM31nikR2qcFnwqxd6t3Xxy1CLFa3xSQhpjOEYwANb2mw7hIFI4w%2BxiFntGI7h3Ggk0nRHs2q1dN0x1rceCAnetJ-QlDal0ABEcdWM3KVN9SndnB0pJIAgvZnKLffzDed4z%2BopISBX4fK9XUd15rS3RfHm0pfKJSNcwwygkgaxIIfx-OHSR98BMwxnPOZwxGovvqIiZwks-rXnsc8xf6-iJ5ZDimqdNe8ho6b3KtvJuu99YkDoO3PgSBu7b1cBCC%2BfA2TzHTn4AISx9ADyHu0ToKBQwYEnuoc%2BgxL7LyVhgSO4CN6x2gX3OB6YMECFPufaEBhBA6k-gsDBiIJgfi-MPQYnhrSWCcNwXhAR1A6CAcdFe9CwFqyYQ3FhsDW6PUMsZa0ghqDfWoAYMsdlAam3NpbFU1tvq-X%2BvZWheUGEkHqP6Ug%2BpSD1FVAoKBWYwQ1GkPKT0i9g6UIMFqPgREkBGNtvbcxdNnDmycdNNRtcNbMP8YIMQwxVDZNyWZMSpAkBJJ9JYAA3gAclKRISplhKmxJMWYx2lifSVLOJUvCkS6lIEqVbT6di7YOMBoIYGgNc7SE4MTV2aVz4rC6D6a8zRjxIDUEMFk55%2BCVIAL4pNAedLSEESplVFFkqqSESCqjcEyI%2BO5XZ1V0HwFonBhhZT2VXA54VFoZl0c9fRpkGhPJdtodqcwugtDaHoCyvACK7k0JIaYx53mr0%2Bek%2BuW8smsNbo2Xah4sXaA0EyM2LzCLdB%2Bq1CkYZ7EwGRao1FEDMnwUiMEk8%2BxX6okiTZekRKkD4pQEsnC7JQ6K2cbgXENd-jplOfBc5AgzLXIpMMO52gxDfXMGeHQEy9BeRGYdViYc6EzXFRdSVD0DJ-NevIX5L0DGKrcNSP%2BmJJh3ELlE2lRqJWTk0Vk0QkggkG0mdM1KuK5mrFRGYZgSArzgwwO6sVNdiq6T8fBfF8p-QCC3Mqo8rKwlIBCK1Q8tQpk2ScNcxEQr9UitScahaUqopnMQnK2qpZ6rcucI83gzzhiXlxBGPs5ExBth1N4Xgcaa1fLrdrIQsqaquJsRqSJHZLA3FOEgRU216jIy2BwUdwrcrVs9RFDFKbtFrgSqez6lDN2KjOOoVgSAHkdGYK1MJFaFb7tAeOpAibSrHvFL62o8pUKaEPC2hqOFKxXlchRXs2MBx7pAVXL9prvUnt1nveQ64pnCQCBZOmegb6MhsrMmACkx1dVrYy8UC4lwrjPSQEJp52UEcvkyS8Aq7zZtCYRIAA&rule=E4VwNgpgzgXAUAAgQWgQY2BeScIJYAmMCAwgEoCiyATAAzUCsytAjACy2K4JQQBuEYHgAuAT2IsuuYSMjEAysICGAI0gIAIngBm2kFDwB7AHYIA6hBUBVAJKkrGgIIIA8iGEJD2hAFkIAW0NgUQQCECFjAHMEFSVhNAALBAAHYEM0aAMoqRw0OIhIoPEEfwCi5FTDNQCcpCV3BKDiAAVMAEcQCDBa0OgMPGSZE2IAHx6kRVV1LV19I1MLazsIYzRDEGNhQSgEJXsnT3dPb1LA4IQAChcXHwBKBEE04FDwvCiYuMT8fyVIiAQ-sZBHF5gAacboepZaLCBL-FYyTAAlbAoamZIDLpvf7CQzoYBKKAJAB0CAAKgk8DsxBi8mAwCF0mhwjsAO5w0yw-6xeJJAwAL3%2BQW%2BvwgEIIeFKxgMJh2EAAHhkIARdnwlHgwFN-gA1MiOHyQ5JKNAiUSglJKYAyZma4AMzymNbSkClZ4AcWaVjZIiSYElImVJTKwWJPTy%2BiwCDG3BwFP%2BaUMHnDvHwOziW38gzeMLxSnp6XyJSCOr1BthSlMSjVGq1CG0wq20uFhmSqPmOzCEUiEK5%2BMMUCgyHTCPm6EMmfcIJMKQShIgpJI48CnKEkT%2BwB2bzQYBABCwENQACFPny8IKeBAPLi8ZTIkl688q%2BrNdUELr9QeEAAJPB3hCYKBDB3NERT%2BHYLhYeg2HlSDqDYTxnltdd7lZH11g8FsZH8M8p1MbRNUiKBPx8cAZGSdRF02NIwAAOUvBCEAAGUMPUiz3MAdjAQwlD3FUDH8UiKwgdYoAZT8bGdXQ8BNBEEAjY4gzORks2w-lcM8LNZUuZBkFKAg%2BAJfxzR0rjWQMpR-FuHpJSNNBhFGcT-D0vBCy2YBsOMdSvAQXtATbacMVbP0gU-ZiBwUvMwHwYwKjSSIAM3H4-mRIECTRTdOThD5eU-ZpExHPMx2AUBNNMbyjStFz6RCPy0sDSVRSImMkFQRxmmWYwCGSQw3mEHZMGEcJTEeYUAO66VoHNFRMCUABrbNdnccd1NZIJZvwwxWSa5rUHkUQoAzf8IA6PAAJKCsQEK3rBAETZR1xI61gEYBrMzY1hHkNZMGIAAOHpsJkSJcIc5qEBsJzlRcrY6zweVoGwZqWFJMhlRADJsq%2BAV-guXgrzxFgaDrYUnSgF1BAQD0vSs0HqFJChPNfU4ig0rCcJA-DflgCEcFQL1-h0vTzP8InngANmQH63UPN9Swpz1ttBlAED5lBkFMoWRYQNhkFFqWZf1OWvW5lrlZTHTjEMZBZzAbwH1IT060i2I0FmiEAGZkdR9GGuSiUpRlaUfLxBgWGoeUQ%2BoBiAHZRZ%2B%2BUY7%2B0G2Dphn1GHO7p1E6SFtQ2FVflB9XR2YUdMw5AoHIkQh2ERs0QhBgF0gS19YNFQIAff5auBoPgESYlmQIJRiQCQZRAAfTyRIIAuanmohZiomQNzhcA4D2wRmNUHB8iAlkghRE87C0Ax09zx4gArfRhClDxYl4FVpyfGtX3fHxP0cAgVVSCBkHw38Eg8K-dAcIXY7Dbh3HgyhKrvC7nXUGvNkjxR4jiPElMEC5ySGcEsBsIK60PAAakekuFYvFZ64ABr%2BXCn1izEDdj0ZQhEN7cFQAdLUyAJSzADp%2BAeShPyRGSCAT8TNghqwgHNT8PJEixXSJkbMn5kiiFxL3BIn5WSWBAHgT89RcQ-GtCwfRkgYyYG0IIFYGQubwIQAA4QyRYAAHo7GRB9CAFQ-dxx2McFYMkNxHBkhsCQAxLA7GsOqOwnQegA7IDUSoDRdjULzTsS4FSbN2yfmsbYmADinGwhcW4-wHivE%2BL8QEgxwTlChI4RE%2BYUT1F4DsVSUm0A7E-VoG7BgaSa4ZIcQopRfcgiRDsQQdIUAylajsRbLYIyeHEgAf4MAABiYRohdIVlFDfHoShkiVzyOlJhuBUCH0jCEyAYTOHVOiRo42z0A7EAAEQAD4AC8CAka0GJLQW5n5DnEB6UERIVztjzDuU8hAtM3kfJyKUZQg9lB7IQPNTqPz2idG6DGQgCgKAAGkVCMUxfTBRABFQw1B-CzUxXwAAYgALQAJoAA1DA9EBBIHIoA5A9FxnCpAqFOqbQkLQBW3B%2BAIi5TgQC4QMjEAwPOLikRiRQAIBczRoNdGJFFSbTAfx5TEAAOQkAcM4dCCklkAB1SRkiEIGB6kUCzQ2JAAKgpngQ8OrjaoE1QqXVvSEhmp4WatwwgXDaD8EpCgxUmj7ENUcbySzXWKyVmqHckYdVuhRGlUc2hnzKmIAG41wYQgjWADqoAA)


## test.log 
<img width="918" height="177" alt="image" src="https://github.com/user-attachments/assets/e44bb090-a01d-4bbd-aa37-2835a1c638df" />



- **Rule File**: `rules/cre-2025-0140/sd-webui-oom.yaml`
- **Test Logs**: `rules/cre-2025-0140/test.log`

### Demo Environment 
https://github.com/Sahelisaha04/n8n-cre-demo  (invitation send)



https://github.com/user-attachments/assets/da3f289b-76ab-4931-a7a1-858b2067ea45




```bash
docker compose -f docker-compose-simple.yml up log-generator
# Test CUDA OOM detection (should detect failure)
cat tests/test.log | preq -r rules/cre-2025-0140/sd-webui-oom.yaml -d


# Test with freshly generated logs
cat tests/generated_failure.log | preq -r rules/cre-2025-0140/sd-webui-oom.yaml -d
```


## References
- [AUTOMATIC1111 WebUI Optimizations](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Optimizations)
- [PyTorch CUDA Memory Management](https://pytorch.org/docs/stable/notes/cuda.html#memory-management)
- [Stable Diffusion Memory Issues](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/8035)

Fixes #130
/claim #130